### PR TITLE
Create base Docker Compose file

### DIFF
--- a/docker/docker-compose-base.yml
+++ b/docker/docker-compose-base.yml
@@ -1,0 +1,25 @@
+version: "3"
+services:
+  database:
+    image: postgres:9.6-alpine
+    environment:
+      - POSTGRES_USER=${DB_USER}
+      - POSTGRES_PASSWORD=${DB_PASSWORD}
+      - POSTGRES_DB=${DB_DATABASE}
+    volumes:
+      - postgres_data:/var/lib/postgresql/data/
+  app:
+    build: ..
+    environment:
+      - DJANGO_SETTINGS_MODULE=curation_portal.settings.development
+      - SECRET_KEY
+      - DB_ENGINE=django.db.backends.postgresql
+      - DB_HOST=database
+      - DB_PORT=5432
+      - DB_DATABASE
+      - DB_USER
+      - DB_PASSWORD
+    depends_on:
+      - database
+volumes:
+  postgres_data:

--- a/docker/nginx-basic-auth/README.md
+++ b/docker/nginx-basic-auth/README.md
@@ -31,14 +31,14 @@ https://docs.nginx.com/nginx/admin-guide/security-controls/configuring-http-basi
 - Apply database migrations.
 
   ```
-  docker-compose -f ./docker/nginx-basic-auth/docker-compose.yml up database
-  docker-compose -f ./docker/nginx-basic-auth/docker-compose.yml run --rm app ./manage.py migrate
+  docker-compose -f ./docker/docker-compose-base.yml -f ./docker/nginx-basic-auth/docker-compose.yml up database
+  docker-compose -f ./docker/docker-compose-base.yml -f ./docker/nginx-basic-auth/docker-compose.yml run --rm app ./manage.py migrate
   ```
 
 - Start environment.
 
   ```
-  docker-compose -f ./docker/nginx-basic-auth/docker-compose.yml up
+  docker-compose -f ./docker/docker-compose-base.yml -f ./docker/nginx-basic-auth/docker-compose.yml up
   ```
 
 - Open web browser to http://localhost:8000.

--- a/docker/nginx-basic-auth/docker-compose.yml
+++ b/docker/nginx-basic-auth/docker-compose.yml
@@ -1,34 +1,11 @@
 version: "3"
 services:
-  database:
-    image: postgres:9.6-alpine
-    environment:
-      - POSTGRES_USER=${DB_USER}
-      - POSTGRES_PASSWORD=${DB_PASSWORD}
-      - POSTGRES_DB=${DB_DATABASE}
-    volumes:
-      - postgres_data:/var/lib/postgresql/data/
-  app:
-    build: ../..
-    environment:
-      - DJANGO_SETTINGS_MODULE=curation_portal.settings.development
-      - SECRET_KEY=${SECRET_KEY}
-      - DB_ENGINE=django.db.backends.postgresql
-      - DB_DATABASE=${DB_DATABASE}
-      - DB_USER=${DB_USER}
-      - DB_PASSWORD=${DB_PASSWORD}
-      - DB_HOST=database
-      - DB_PORT=5432
-    depends_on:
-      - database
   web:
     image: nginx:stable-alpine
     volumes:
-      - ./nginx.conf:/etc/nginx/nginx.conf
-      - ./htpasswd:/etc/nginx/htpasswd
+      - ./nginx-basic-auth/nginx.conf:/etc/nginx/nginx.conf
+      - ./nginx-basic-auth/htpasswd:/etc/nginx/htpasswd
     ports:
       - 8000:80
     depends_on:
       - app
-volumes:
-  postgres_data:


### PR DESCRIPTION
Based on https://github.com/macarthur-lab/variant-curation-portal/pull/13#issuecomment-495194233.

In anticipation of different Docker Compose environments for different authentication methods, splits the base services (app and database) into a separate Compose file that can be reused.