### PR TITLE
Remove deprecated Babel polyfill

### DIFF
--- a/assets/index.js
+++ b/assets/index.js
@@ -1,4 +1,4 @@
-import "@babel/polyfill";
+import "core-js/stable";
 import React from "react";
 import ReactDOM from "react-dom";
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "webpack-dev-server": "^3"
   },
   "dependencies": {
-    "@babel/polyfill": "^7",
     "core-js": "^3.0.0",
     "lodash": "^4.17",
     "mousetrap": "^1.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -626,7 +626,7 @@
     "@babel/helper-regex" "^7.4.4"
     regexpu-core "^4.5.4"
 
-"@babel/polyfill@^7", "@babel/polyfill@^7.0.0":
+"@babel/polyfill@^7.0.0":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/polyfill/-/polyfill-7.4.4.tgz#78801cf3dbe657844eeabf31c1cae3828051e893"
   integrity sha512-WlthFLfhQQhh+A2Gn5NSFl0Huxz36x86Jn+E9OW7ibK8edKPq+KLy4apM1yDpQ8kJOVi1OVjpP4vSDLdrI04dg==


### PR DESCRIPTION
The `@babel/polyfill` package is deprecated. This replaces it with a direct import from `core-js`. Since there's nothing in this project using generators or async functions, it omits `regenerator-runtime`.

https://github.com/zloirock/core-js/blob/master/docs/2019-03-19-core-js-3-babel-and-a-look-into-the-future.md#babel