### PR TITLE
Add bottom padding to pages to account for fixed footer

### DIFF
--- a/assets/components/App.js
+++ b/assets/components/App.js
@@ -65,7 +65,7 @@ class App extends Component {
             </Container>
           </Menu>
 
-          <div style={{ paddingTop: "65px" }}>
+          <div style={{ paddingBottom: "35px", paddingTop: "65px" }}>
             <Switch>
               <Route
                 exact


### PR DESCRIPTION
Because the header and footer bars are fixed position, the main content scrolls under them. Without padding to account for the size of the bar, the last bit of content on a long page would be hidden under the footer.