### PR TITLE
Limit debug logs in development settings

### DIFF
--- a/curation_portal/settings/development.py
+++ b/curation_portal/settings/development.py
@@ -10,7 +10,9 @@ LOGGING = {
     "version": 1,
     "disable_existing_loggers": False,
     "handlers": {"console": {"level": "DEBUG", "class": "logging.StreamHandler"}},
-    "loggers": {"django": {"handlers": ["console"], "level": "DEBUG", "propagate": False}},
+    "loggers": {
+        "django.db.backends": {"handlers": ["console"], "level": "DEBUG", "propagate": False}
+    },
 }
 
 SECURE_SSL_REDIRECT = False


### PR DESCRIPTION
The goal of the logging configuration in the development settings was to log database queries to make sure pages weren't making unnecessary queries. However, allowing debug logs for all of Django is a bit too verbose, especially when starting up the Django dev server.