### PR TITLE
Fix sample sorting

### DIFF
--- a/scripts/convert_vcf_to_json.py
+++ b/scripts/convert_vcf_to_json.py
@@ -119,7 +119,7 @@ def convert_vcf_to_json(vcf_path, output_path, max_samples_per_genotype=5):
                     }
                 )
 
-            for sample in sorted(samples, key=lambda s: getattr(s, "GQ", None) or 0):
+            for sample in sorted(samples, key=lambda s: getattr(s.data, "GQ", None) or 0):
                 if sample["GT"] not in {"0/1", "1/1"}:
                     continue
 


### PR DESCRIPTION
87c6225574055f8d67dc56914739d06727561098 mistakenly calls `getattr` on the sample object itself instead of `sample.data`.