### PR TITLE
Update Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -53,4 +53,9 @@ RUN chown -R app:app .
 USER app
 
 # Run
-CMD gunicorn curation_portal.wsgi --bind=0.0.0.0:8000
+CMD ["gunicorn", \
+  "--bind", ":8000", \
+  "--log-file", "-", \
+  "--workers", "2", "--threads", "4", "--worker-class", "gthread", \
+  "--worker-tmp-dir", "/dev/shm", \
+  "curation_portal.wsgi"]


### PR DESCRIPTION
* Copy only required files for front end build. This allows Docker to use the cached front end layer if changes have been made only to Python code.
* Update gunicorn command based on recommendations in https://pythonspeed.com/articles/gunicorn-in-docker/.