### PR TITLE
Use Django Rest Framework's generic error views

### DIFF
--- a/curation_portal/urls.py
+++ b/curation_portal/urls.py
@@ -93,3 +93,6 @@ urlpatterns = [
     ),
     path("api/profile/", ProfileView.as_view(), name="api-profile"),
 ]
+
+handler400 = "rest_framework.exceptions.bad_request"
+handler500 = "rest_framework.exceptions.server_error"


### PR DESCRIPTION
Use Django Rest Framework's [generic error views](https://www.django-rest-framework.org/api-guide/exceptions/#generic-error-views) for handling 400 and 500 errors. These send JSON responses (as opposed to Django's default HTML responses) for those errors.