### PR TITLE
Redirect to admin page after creating a project or adding variants

### DIFF
--- a/assets/components/pages/project/admin/UploadVariantsPage.js
+++ b/assets/components/pages/project/admin/UploadVariantsPage.js
@@ -48,7 +48,7 @@ class UploadVariantsPage extends Component {
         return response.json();
       })
       .then(() => {
-        history.push(`/project/${project.id}/`);
+        history.push(`/project/${project.id}/admin/`);
       })
       .catch(error => {
         this.setState({ isSaving: false, saveError: error });

--- a/assets/components/pages/projects/CreateProjectPage.js
+++ b/assets/components/pages/projects/CreateProjectPage.js
@@ -47,7 +47,7 @@ class CreateProjectPage extends Component {
       })
       .then(project => {
         this.setState({ isSaving: false });
-        history.push(`/project/${project.id}/`);
+        history.push(`/project/${project.id}/admin/`);
       })
       .catch(() => {
         this.setState({ isSaving: false, lastSaveDidFail: true });


### PR DESCRIPTION
Currently, after creating a project or uploading variants, you're redirected to the project page with the list of assigned variants. However, immediately after either of those tasks, there won't be any curation assignments for the project. Redirecting to project admin page after those tasks requires less clicks to complete the workflow of create project => upload variants => assign curators.

Resolves #45.