### PR TITLE
Refactor view permissions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,7 @@ Check formatting of JS code with `yarn run prettier --check 'assets/**'`.
 - [Python 3.6+](https://www.python.org/)
 - [Django](https://www.djangoproject.com/)
 - [Django REST framework](https://www.django-rest-framework.org/)
+- [rules](https://pypi.org/project/rules/)
 - [Django webpack loader](https://github.com/owais/django-webpack-loader)
 - [WhiteNoise](https://pypi.org/project/whitenoise/)
 - [React](https://reactjs.org/)

--- a/curation_portal/rules.py
+++ b/curation_portal/rules.py
@@ -1,0 +1,25 @@
+import rules
+
+from curation_portal.models import CurationAssignment
+
+
+@rules.predicate
+def is_project_owner(user, project):
+    return project.owners.filter(id=user.id).exists()
+
+
+@rules.predicate
+def is_project_curator(user, project):
+    return CurationAssignment.objects.filter(curator=user, variant__project=project).exists()
+
+
+rules.add_perm("curation_portal.view_project", is_project_owner | is_project_curator)
+rules.add_perm("curation_portal.change_project", is_project_owner)
+
+
+@rules.predicate
+def is_variant_curator(user, variant):
+    return CurationAssignment.objects.filter(curator=user, variant=variant).exists()
+
+
+rules.add_perm("curation_portal.curate_variant", is_variant_curator)

--- a/curation_portal/settings/base.py
+++ b/curation_portal/settings/base.py
@@ -41,6 +41,7 @@ INSTALLED_APPS = [
     "django.contrib.sessions",
     "django.contrib.messages",
     "rest_framework",
+    "rules.apps.AutodiscoverRulesConfig",
     "webpack_loader",
     "curation_portal",
 ]
@@ -94,7 +95,10 @@ DATABASES = {
 
 AUTH_USER_MODEL = "curation_portal.User"
 
-AUTHENTICATION_BACKENDS = ["django.contrib.auth.backends.RemoteUserBackend"]
+AUTHENTICATION_BACKENDS = [
+    "rules.permissions.ObjectPermissionBackend",
+    "django.contrib.auth.backends.RemoteUserBackend",
+]
 
 # Password validation
 # https://docs.djangoproject.com/en/2.2/ref/settings/#auth-password-validators

--- a/curation_portal/views/project.py
+++ b/curation_portal/views/project.py
@@ -1,5 +1,6 @@
 from django.db.models import Count
-from rest_framework.exceptions import NotFound, PermissionDenied
+from rest_framework.exceptions import NotFound
+from rest_framework.generics import get_object_or_404
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.serializers import ModelSerializer
@@ -17,59 +18,53 @@ class ProjectSerializer(ModelSerializer):
 class ProjectView(APIView):
     permission_classes = (IsAuthenticated,)
 
+    def get_project(self):
+        project = get_object_or_404(Project, id=self.kwargs["project_id"])
+        if not self.request.user.has_perm("curation_portal.view_project", project):
+            raise NotFound
+        return project
+
     def get(self, request, *args, **kwargs):
-        project_id = kwargs["project_id"]
-        try:
-            project = Project.objects.get(id=project_id)
-        except Project.DoesNotExist:
-            raise NotFound("Project does not exist")
-        else:
-            user_is_owner = project.owners.filter(id=request.user.id).exists()
-            user_is_curator = request.user.curation_assignments.filter(
-                variant__project=project
-            ).exists()
+        project = self.get_project()
 
-            if not (user_is_owner or user_is_curator):
-                raise PermissionDenied("You do not have permission to view this page")
+        response = ProjectSerializer(project).data
 
-            response = ProjectSerializer(project).data
+        if project.owners.filter(id=request.user.id).exists():
+            response["owners"] = [owner.username for owner in project.owners.all()]
 
-            if user_is_owner:
-                response["owners"] = [owner.username for owner in project.owners.all()]
-
-                total_assignments_by_curator = dict(
-                    CurationAssignment.objects.filter(variant__project=project)
-                    .values_list("curator__username")
-                    .annotate(num_assignments=Count("variant"))
-                    .all()
+            total_assignments_by_curator = dict(
+                CurationAssignment.objects.filter(variant__project=project)
+                .values_list("curator__username")
+                .annotate(num_assignments=Count("variant"))
+                .all()
+            )
+            completed_assignments_by_curator = dict(
+                CurationAssignment.objects.filter(
+                    variant__project=project, result__verdict__isnull=False
                 )
-                completed_assignments_by_curator = dict(
-                    CurationAssignment.objects.filter(
-                        variant__project=project, result__verdict__isnull=False
-                    )
-                    .values_list("curator__username")
-                    .annotate(num_assignments=Count("variant"))
-                    .all()
-                )
+                .values_list("curator__username")
+                .annotate(num_assignments=Count("variant"))
+                .all()
+            )
 
-                response["assignments"] = {
-                    curator: {
-                        "total": num_assignments,
-                        "completed": completed_assignments_by_curator.get(curator, 0),
-                    }
-                    for curator, num_assignments in total_assignments_by_curator.items()
+            response["assignments"] = {
+                curator: {
+                    "total": num_assignments,
+                    "completed": completed_assignments_by_curator.get(curator, 0),
                 }
+                for curator, num_assignments in total_assignments_by_curator.items()
+            }
 
-                total_variants = project.variants.count()
-                num_curated_variants = (
-                    CurationAssignment.objects.filter(
-                        variant__project=project, result__verdict__isnull=False
-                    )
-                    .values("variant__variant_id")
-                    .distinct()
-                    .count()
+            total_variants = project.variants.count()
+            num_curated_variants = (
+                CurationAssignment.objects.filter(
+                    variant__project=project, result__verdict__isnull=False
                 )
+                .values("variant__variant_id")
+                .distinct()
+                .count()
+            )
 
-                response["variants"] = {"total": total_variants, "curated": num_curated_variants}
+            response["variants"] = {"total": total_variants, "curated": num_curated_variants}
 
-            return Response(response)
+        return Response(response)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 django==2.2.1
 djangorestframework==3.9.1
 django-webpack-loader==0.6.0
+rules==2.0.1
 whitenoise==4.1.2

--- a/tests/test_create_project_assignments.py
+++ b/tests/test_create_project_assignments.py
@@ -36,7 +36,7 @@ def test_creating_project_assignments_requires_authentication(db_setup):
 
 
 @pytest.mark.parametrize(
-    "username,expected_status_code", [("user1@example.com", 200), ("user2@example.com", 403)]
+    "username,expected_status_code", [("user1@example.com", 200), ("user2@example.com", 404)]
 )
 def test_project_assignments_can_only_be_set_by_project_owners(
     db_setup, username, expected_status_code

--- a/tests/test_curate_variant_view.py
+++ b/tests/test_curate_variant_view.py
@@ -46,10 +46,10 @@ def test_curate_variant_view_requires_authentication(db_setup):
 @pytest.mark.parametrize(
     "username,expected_status_code",
     [
-        ("user1@example.com", 403),
+        ("user1@example.com", 404),
         ("user2@example.com", 200),
-        ("user3@example.com", 403),
-        ("user4@example.com", 403),
+        ("user3@example.com", 404),
+        ("user4@example.com", 404),
     ],
 )
 def test_curate_variant_view_can_only_be_viewed_by_variant_curators(

--- a/tests/test_project_assignments_view.py
+++ b/tests/test_project_assignments_view.py
@@ -50,7 +50,7 @@ def test_project_assignments_list_requires_authentication(db_setup):
         ("user1@example.com", 200),
         ("user2@example.com", 200),
         ("user3@example.com", 200),
-        ("user4@example.com", 403),
+        ("user4@example.com", 404),
     ],
 )
 def test_project_assignments_list_can_only_be_viewed_by_project_curators(

--- a/tests/test_project_variants_view.py
+++ b/tests/test_project_variants_view.py
@@ -39,7 +39,7 @@ def test_upload_variants_requires_authentication(db_setup):
 
 @pytest.mark.parametrize(
     "username,expected_status_code",
-    [("user1@example.com", 200), ("user2@example.com", 403), ("user3@example.com", 403)],
+    [("user1@example.com", 200), ("user2@example.com", 403), ("user3@example.com", 404)],
 )
 def test_variants_can_only_be_uploaded_by_project_owners(db_setup, username, expected_status_code):
     client = APIClient()

--- a/tests/test_project_view.py
+++ b/tests/test_project_view.py
@@ -50,7 +50,7 @@ def test_project_view_requires_authentication(db_setup):
         ("user1@example.com", 200),
         ("user2@example.com", 200),
         ("user3@example.com", 200),
-        ("user4@example.com", 403),
+        ("user4@example.com", 404),
     ],
 )
 def test_project_view_can_only_be_viewed_by_project_owners_or_curators(


### PR DESCRIPTION
This adds the [rules](https://github.com/dfunckt/django-rules) package to implement Django [object permissions](https://docs.djangoproject.com/en/2.2/topics/auth/customizing/#handling-object-permissions).

This allows code such as `user.has_perm("app.permission", obj)`, the result of which is defined by rules in `rules.py`. Views are refactored to use this instead of directly checking for project ownership/assignments.