### PR TITLE
Refresh project after uploading variants or assigning curators

### DIFF
--- a/assets/components/Fetch.js
+++ b/assets/components/Fetch.js
@@ -86,13 +86,13 @@ class BaseFetch extends Component {
 
   render() {
     const { children } = this.props;
-    return children(this.state);
+    return children({ ...this.state, refresh: this.loadData.bind(this) });
   }
 }
 
 const Fetch = ({ children, url }) => (
   <BaseFetch url={url}>
-    {({ data, error, isFetching }) => {
+    {({ data, error, isFetching, refresh }) => {
       if (isFetching) {
         return (
           <Dimmer active inverted>
@@ -113,7 +113,7 @@ const Fetch = ({ children, url }) => (
         );
       }
 
-      return children({ data });
+      return children({ data, refresh });
     }}
   </BaseFetch>
 );

--- a/assets/components/pages/project/ProjectPage.js
+++ b/assets/components/pages/project/ProjectPage.js
@@ -15,7 +15,7 @@ import CurateVariantPage from "./curate/CurateVariantPage";
 const ProjectPage = ({ match, projectId, user }) => (
   <Container fluid>
     <Fetch url={`/api/project/${projectId}/`}>
-      {({ data: project }) => {
+      {({ data: project, refresh }) => {
         return (
           <Switch>
             <Route
@@ -33,13 +33,22 @@ const ProjectPage = ({ match, projectId, user }) => (
             <Route
               exact
               path={`${match.path}assign/`}
-              render={props => <AssignVariantsPage {...props} project={project} user={user} />}
+              render={props => (
+                <AssignVariantsPage
+                  {...props}
+                  project={project}
+                  user={user}
+                  refreshProject={refresh}
+                />
+              )}
             />
 
             <Route
               exact
               path={`${match.path}variants/`}
-              render={props => <UploadVariantsPage {...props} project={project} />}
+              render={props => (
+                <UploadVariantsPage {...props} project={project} refreshProject={refresh} />
+              )}
             />
 
             <Route

--- a/assets/components/pages/project/admin/AssignVariantsPage.js
+++ b/assets/components/pages/project/admin/AssignVariantsPage.js
@@ -16,6 +16,7 @@ class AssignVariantsPage extends Component {
       id: PropTypes.number.isRequired,
       name: PropTypes.string.isRequired,
     }).isRequired,
+    refreshProject: PropTypes.func.isRequired,
     user: PropTypes.shape({
       username: PropTypes.string.isRequired,
     }),
@@ -38,7 +39,7 @@ class AssignVariantsPage extends Component {
   form = React.createRef();
 
   onSubmit = () => {
-    const { history, project } = this.props;
+    const { history, project, refreshProject } = this.props;
     const { assignments } = this.state;
 
     this.setState({ isSaving: true, saveError: null });
@@ -58,6 +59,7 @@ class AssignVariantsPage extends Component {
         return response.json();
       })
       .then(() => {
+        refreshProject();
         history.push(`/project/${project.id}/admin/`);
       })
       .catch(error => {

--- a/assets/components/pages/project/admin/UploadVariantsPage.js
+++ b/assets/components/pages/project/admin/UploadVariantsPage.js
@@ -15,6 +15,7 @@ class UploadVariantsPage extends Component {
       id: PropTypes.number.isRequired,
       name: PropTypes.string.isRequired,
     }).isRequired,
+    refreshProject: PropTypes.func.isRequired,
   };
 
   variantData = null;
@@ -29,7 +30,7 @@ class UploadVariantsPage extends Component {
   };
 
   onSubmit = () => {
-    const { history, project } = this.props;
+    const { history, project, refreshProject } = this.props;
 
     this.setState({ isSaving: true, saveError: null });
     fetch(`/api/project/${project.id}/variants/`, {
@@ -48,6 +49,7 @@ class UploadVariantsPage extends Component {
         return response.json();
       })
       .then(() => {
+        refreshProject();
         history.push(`/project/${project.id}/admin/`);
       })
       .catch(error => {


### PR DESCRIPTION
To avoid unnecessary requests, the UI fetches the project once and shares that data between all individual project pages (such as the project admin page, assign curators page, etc.). However, when changes are made to the project on one of those pages (variants are uploaded or curators assigned) the UI shows stale data. This change refreshes project data after uploading variants or assigning curators.

Resolves #31.