### PR TITLE
Link to assigned vs owned projects from variants list

### DIFF
--- a/assets/components/pages/project/assignments/ProjectAssignmentsPage.js
+++ b/assets/components/pages/project/assignments/ProjectAssignmentsPage.js
@@ -16,7 +16,7 @@ const ProjectAssignmentsPage = ({ project }) => {
         {project.name}
       </Header>
       <div>
-        <Link to="/projects/">All projects</Link>
+        <Link to="/assignments/">All assigned projects</Link>
       </div>
 
       <Fetch url={`/api/project/${project.id}/assignments/`}>


### PR DESCRIPTION
When someone is viewing the list of variants to curate for a project, they are acting in a curator role and more likely to want to return to the list of assigned projects vs the list of owned projects.