### PR TITLE
Run webpack-dev-server with yarn instead of modifying path

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -4,13 +4,12 @@ cd $(dirname "${BASH_SOURCE}")
 
 export DJANGO_SETTINGS_MODULE="curation_portal.settings.development"
 
-export PATH=$PATH:./node_modules/.bin
 export NODE_ENV=development
 
 ./manage.py runserver &
 DJANGO_PID=$!
 
-webpack-dev-server --hot &
+yarn run webpack-dev-server --hot &
 WEBPACK_PID=$!
 
 trap "kill ${WEBPACK_PID}; pkill -P ${DJANGO_PID}; exit 1" INT


### PR DESCRIPTION
[yarn run](https://yarnpkg.com/lang/en/docs/cli/run/) can run executables inside `node_modules/.bin`.