### PR TITLE
Use frozen lockfile in Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR /app
 # Install dependencies
 COPY package.json .
 COPY yarn.lock .
-RUN yarn
+RUN yarn install --frozen-lockfile
 
 COPY babel.config.js .
 COPY webpack.config.js .


### PR DESCRIPTION
Requiring that yarn.lock not be updated during installation helps with reproducible builds.

https://yarnpkg.com/en/docs/cli/install#toc-yarn-install-frozen-lockfile