### PR TITLE
Document simulating authenticated user with start.sh

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,8 +24,10 @@
 
 - Start Django and webpack development servers
 
+  Set REMOTE_USER to simulate an authenticated user
+
   ```
-  ./start.sh
+  REMOTE_USER=someuser ./start.sh
   ```
 
 - Open browser to http://localhost:3000


### PR DESCRIPTION
Using start.sh for development, webpack-dev-server proxies requests to the API. Since it does not have any authentication mechanism, REMOTE_USER should be set on the command line.