### PR TITLE
Remove unnecessary Babel plugin

### DIFF
--- a/babel.config.js
+++ b/babel.config.js
@@ -12,5 +12,5 @@ module.exports = {
       },
     ],
   ],
-  plugins: ["@babel/plugin-proposal-object-rest-spread", "@babel/plugin-proposal-class-properties"],
+  plugins: ["@babel/plugin-proposal-class-properties"],
 };

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "@babel/core": "^7",
     "@babel/node": "^7",
     "@babel/plugin-proposal-class-properties": "^7",
-    "@babel/plugin-proposal-object-rest-spread": "^7",
     "@babel/preset-env": "^7",
     "@babel/preset-react": "^7",
     "babel-eslint": "^10",

--- a/yarn.lock
+++ b/yarn.lock
@@ -291,7 +291,7 @@
     "@babel/helper-plugin-utils" "^7.0.0"
     "@babel/plugin-syntax-json-strings" "^7.2.0"
 
-"@babel/plugin-proposal-object-rest-spread@^7", "@babel/plugin-proposal-object-rest-spread@^7.4.4":
+"@babel/plugin-proposal-object-rest-spread@^7.4.4":
   version "7.4.4"
   resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-object-rest-spread/-/plugin-proposal-object-rest-spread-7.4.4.tgz#1ef173fcf24b3e2df92a678f027673b55e7e3005"
   integrity sha512-dMBG6cSPBbHeEBdFXeQ2QLc5gUpg4Vkaz8octD4aoW/ISO+jBOcsuxYL7bsb5WSu8RLP6boxrBIALEHgoHtO9g==


### PR DESCRIPTION
Object rest/spread properties are included in [babel/preset-env](https://babeljs.io/docs/en/babel-preset-env).