### PR TITLE
Add development configuration for Docker Compose

### DIFF
--- a/docker/docker-compose-dev.yml
+++ b/docker/docker-compose-dev.yml
@@ -1,0 +1,6 @@
+version: "3"
+services:
+  app:
+    command: ./manage.py runserver app:8000
+    volumes:
+      - ../curation_portal:/app/curation_portal


### PR DESCRIPTION
The Docker Compose configuration uses the application code that is baked into the container image and runs it with gunicorn. To make it easier to use the Dockerized application in development, this adds an override configuration file to mount the application code from the host machine and run it with Django's development server.

Usage:
```
docker-compose \
  -f ./docker/docker-compose-base.yml \
  -f ./docker/nginx-basic-auth/docker-compose.yml \
  -f ./docker/docker-compose-dev.yml \
  up
```