### PR TITLE
Show spinners while uploading variants or assigning curators

### DIFF
--- a/assets/components/pages/project/admin/AssignVariantsPage.js
+++ b/assets/components/pages/project/admin/AssignVariantsPage.js
@@ -164,7 +164,12 @@ class AssignVariantsPage extends Component {
                   </List>
                 </Segment>
                 <Segment attached>
-                  <Button disabled={assignments.length === 0 || isSaving} primary type="submit">
+                  <Button
+                    disabled={assignments.length === 0 || isSaving}
+                    loading={isSaving}
+                    primary
+                    type="submit"
+                  >
                     Assign curators
                   </Button>
                   {saveError && <Message error header="Failed to assign curators" />}

--- a/assets/components/pages/project/admin/UploadVariantsPage.js
+++ b/assets/components/pages/project/admin/UploadVariantsPage.js
@@ -106,7 +106,12 @@ class UploadVariantsPage extends Component {
         <Segment attached>
           <Header as="h4">Upload variants from file</Header>
           <Form error={Boolean(fileReadError || saveError)} onSubmit={this.onSubmit}>
-            <Button as="label" htmlFor="variant-file">
+            <Button
+              as="label"
+              disabled={isReadingFile}
+              loading={isReadingFile}
+              htmlFor="variant-file"
+            >
               <Icon name="upload" />
               {fileName || "Select variant file"}
               <input
@@ -119,7 +124,7 @@ class UploadVariantsPage extends Component {
             </Button>
             {fileReadError && <Message error header="Failed to read file" />}
             {saveError && <Message error header="Failed to upload variants" />}
-            <Button disabled={!hasFileData || isSaving} primary type="submit">
+            <Button disabled={!hasFileData || isSaving} loading={isSaving} primary type="submit">
               Upload
             </Button>
           </Form>


### PR DESCRIPTION
When making a request that may take a long time, show a spinner on the button that started the request.

Resolves #83