### PR TITLE
Optimize query for download results view

### DIFF
--- a/curation_portal/views/project_admin.py
+++ b/curation_portal/views/project_admin.py
@@ -91,7 +91,7 @@ class DownloadProjectResultsView(LoginRequiredMixin, View):
             CurationAssignment.objects.filter(
                 variant__project=project, result__verdict__isnull=False
             )
-            .select_related("curator", "variant")
+            .select_related("curator", "variant", "result")
             .all()
         )
 


### PR DESCRIPTION
Select all results to download up front instead of making a separate query for each result.

Resolves #86