### PR TITLE
Remove unused data from project assignments endpoint

### DIFF
--- a/curation_portal/views/project_assignments.py
+++ b/curation_portal/views/project_assignments.py
@@ -74,12 +74,6 @@ class NewAssignmentSerializer(serializers.Serializer):
         raise NotImplementedError
 
 
-class ProjectSerializer(serializers.ModelSerializer):
-    class Meta:
-        model = Project
-        fields = ("id", "name")
-
-
 class ProjectAssignmentsView(APIView):
     permission_classes = (IsAuthenticated,)
 
@@ -106,11 +100,8 @@ class ProjectAssignmentsView(APIView):
             .all()
         )
 
-        project_serializer = ProjectSerializer(project)
         assignments_serializer = AssignmentSerializer(assignments, many=True)
-        return Response(
-            {"project": project_serializer.data, "assignments": assignments_serializer.data}
-        )
+        return Response({"assignments": assignments_serializer.data})
 
     def post(self, request, *args, **kwargs):
         project = self.get_project()


### PR DESCRIPTION
Currently, the `/project/:id/assignments` endpoint returns the project as well as the list of assignments. However, the project part of the response is never used.