### PR TITLE
Fix label for uncertain verdict

### DIFF
--- a/assets/constants/verdicts.js
+++ b/assets/constants/verdicts.js
@@ -11,7 +11,7 @@ export const verdictColors = {
 export const verdictLabels = {
   lof: "LoF",
   likely_lof: "Likely LoF",
-  uncertain_lof: "¯\\_(ツ)_/¯",
+  uncertain: "¯\\_(ツ)_/¯",
   likely_not_lof: "Likely not loF",
   not_lof: "Not LoF",
 };


### PR DESCRIPTION
The values of the verdict inputs in the curation form are defined in [verdicts.js](https://github.com/macarthur-lab/variant-curation-portal/blob/c56c1b49d181164e933a8f29716b47ad61679dbb/assets/constants/verdicts.js#L1) as
* lof
* likely_lof
* uncertain
* likely_not_lof
* not_lof

The key for the uncertain verdict's label is currently incorrect.

