### PR TITLE
Show placeholder if UCSC gene view can't be shown

### DIFF
--- a/assets/components/pages/project/curate/CurateVariantPage.js
+++ b/assets/components/pages/project/curate/CurateVariantPage.js
@@ -60,9 +60,7 @@ class CurateVariantPage extends React.Component {
                 ? variant.liftover_variant_id
                 : variant.variant_id;
 
-            const shouldShowUCSCGeneView = !!variant.annotations.find(
-              a => a.gene_symbol && a.transcript_id
-            );
+            const hasAnnotations = variant.annotations.length > 0;
 
             return (
               <React.Fragment>
@@ -158,11 +156,7 @@ class CurateVariantPage extends React.Component {
                             <a href="#ucsc">UCSC (variant)</a>
                           </List.Item>
                           <List.Item>
-                            {shouldShowUCSCGeneView ? (
-                              <a href="#ucsc-gene">UCSC (gene)</a>
-                            ) : (
-                              "UCSC (gene)"
-                            )}
+                            {hasAnnotations ? <a href="#ucsc-gene">UCSC (gene)</a> : "UCSC (gene)"}
                           </List.Item>
                         </List>
                       </span>

--- a/assets/components/pages/project/curate/UCSC.js
+++ b/assets/components/pages/project/curate/UCSC.js
@@ -1,5 +1,6 @@
 import PropTypes from "prop-types";
 import React from "react";
+import { Header, Segment } from "semantic-ui-react";
 
 /**
  * Documentation for linking to the UCSC browser:
@@ -33,13 +34,22 @@ UCSCVariantView.propTypes = {
 };
 
 export const UCSCGeneView = ({ variant }) => {
-  const annotation = variant.annotations.find(a => a.gene_symbol && a.transcript_id);
+  const hasAnnotations = variant.annotations.length > 0;
 
-  if (!annotation) {
-    return null;
+  if (!hasAnnotations) {
+    return (
+      <Segment placeholder textAlign="center">
+        <Header>
+          UCSC gene view unavailable for this variant
+          <br />
+          No annotations
+        </Header>
+      </Segment>
+    );
   }
 
   const assembly = variant.reference_genome === "GRCh38" ? "hg38" : "hg19";
+  const annotation = variant.annotations[0];
 
   return (
     <iframe


### PR DESCRIPTION
If a variant has no annotations, there is no way to tell which gene should be shown in the UCSC gene view. In that case, currently nothing is rendered. This adds a placeholder message explaining why it can't be shown.

Resolves #98