### PR TITLE
Measure test coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ node_modules
 __pycache__
 static/bundles
 webpack-stats.json
+.coverage
+htmlcov
 .tox
 
 # dotenv for Docker Compose

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -39,6 +39,16 @@
 Backend tests are written using [pytest](https://docs.pytest.org/).
 Run tests with either `pytest` or `tox -e py36`.
 
+#### Coverage
+
+[pytest-cov](https://pytest-cov.readthedocs.io) is used to generate coverage reports.
+
+To generate and view an HTML coverage report, use:
+```
+pytest --cov-report=html
+python3 -m http.server --directory htmlcov
+```
+
 ## Conventions
 
 ### Python

--- a/pytest.ini
+++ b/pytest.ini
@@ -2,3 +2,5 @@
 DJANGO_SETTINGS_MODULE = curation_portal.settings.test
 
 testpaths = tests
+
+addopts = --cov curation_portal --cov-branch

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,5 +4,6 @@ pydocstyle==3.0.0
 pylint==2.3.1
 pylint-django==2.0.6
 pytest==4.3.1
+pytest-cov==2.7.1
 pytest-django==3.4.8
 tox==3.7.0


### PR DESCRIPTION
Measure test coverage using [coverage.py](https://coverage.readthedocs.io) through [pytest-cov](https://pytest-cov.readthedocs.io).