### PR TITLE
Add option to download template file for assignments

### DIFF
--- a/assets/components/pages/project/admin/AssignVariantsPage.js
+++ b/assets/components/pages/project/admin/AssignVariantsPage.js
@@ -7,6 +7,26 @@ import api from "../../../../api";
 import { PermissionRequired } from "../../../../permissions";
 import DocumentTitle from "../../../DocumentTitle";
 
+const downloadTemplateCSV = project => {
+  return api.get(`/project/${project.id}/variants/`).then(response => {
+    const templateData = response.variants.map(variant => ["CURATOR", variant.variant_id]);
+    const csv = `${templateData.map(row => row.join(",")).join("\r\n")}\r\n`;
+    const filename = `${project.name}_assignments_template.csv`;
+
+    const blob = new Blob([csv], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const link = document.createElement("a");
+    link.setAttribute("href", url);
+    link.setAttribute("download", filename);
+    link.onClick = () => {
+      URL.revokeObjectURL(url);
+      link.remove();
+    };
+    document.body.appendChild(link);
+    link.click();
+  });
+};
+
 class AssignVariantsPage extends Component {
   static propTypes = {
     history: PropTypes.shape({
@@ -143,6 +163,15 @@ class AssignVariantsPage extends Component {
                   type="file"
                   onChange={e => this.onSelectFile(e.target.files[0])}
                 />
+              </Button>
+
+              <Button
+                type="button"
+                onClick={() => {
+                  downloadTemplateCSV(project);
+                }}
+              >
+                Download template
               </Button>
             </Segment>
             <Message attached>


### PR DESCRIPTION
Assigning curators from a file requires a file with rows containing curator username and variant ID. However, there is currently no way to get the list of variant IDs in the project except from the originally uploaded variants file.

This adds a button to download a template assignments file with a row for each variant in the project. The "CURATOR" placeholders can be replaced and the edited file uploaded to assign curators.

Resolves #101