### PR TITLE
Throw error if convert VCF script encounters a multiallelic row

### DIFF
--- a/scripts/convert_vcf_to_json.py
+++ b/scripts/convert_vcf_to_json.py
@@ -75,6 +75,11 @@ def convert_vcf_to_json(
         )
 
         for row in tqdm(reader, unit=" rows"):
+            if len(row.ALT) > 1:
+                raise Exception(
+                    "VCF contains multiallelic rows, which are not supported by this script"
+                )
+
             samples = list(row.samples)
 
             # Parse CSQ field


### PR DESCRIPTION
The convert VCF to JSON script does not handle rows with multiple alt alleles. It only extracts one variant (with the first alt allele) per row in the VCF. It also does not filter samples based on which alt allele they contain.

https://github.com/macarthur-lab/variant-curation-portal/blob/31e8e9870a0137f55c9eca989e4f779bdf2e8421/scripts/convert_vcf_to_json.py#L93-L95

Currently, this results in silently losing variants or associating samples with the wrong variant. This changes the script to throw an error if it encounters such a row.

Relates to #107