### PR TITLE
Add support for query parameters to api client

### DIFF
--- a/assets/api.js
+++ b/assets/api.js
@@ -1,3 +1,5 @@
+import queryString from "query-string";
+
 import getCookie from "./utilities/getCookie";
 
 class ApiClient {
@@ -22,8 +24,10 @@ class ApiClient {
     });
   }
 
-  get(path) {
-    return this.request(path, {});
+  get(path, params = {}) {
+    const query = queryString.stringify(params);
+    const requestPath = query ? `${path}?${query}` : path;
+    return this.request(requestPath, {});
   }
 
   patch(path, data) {

--- a/assets/api.test.js
+++ b/assets/api.test.js
@@ -16,6 +16,21 @@ describe("ApiClient", () => {
     global.fetch.mockClear();
   });
 
+  it("should add query parameters", async () => {
+    global.fetch = jest.fn().mockImplementation(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({}),
+      })
+    );
+
+    await api.get("/projects/", { search: "foo" });
+
+    expect(global.fetch).toHaveBeenCalledWith("/api/projects/?search=foo", {});
+
+    global.fetch.mockClear();
+  });
+
   it("should handle failed requests", async () => {
     global.fetch = jest.fn().mockImplementation(() => Promise.reject(new Error("Failed to fetch")));
 

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "lodash": "^4.17",
     "mousetrap": "^1.6",
     "prop-types": "^15.7",
+    "query-string": "5",
     "react": "^16.8",
     "react-dom": "^16.8",
     "react-router-dom": "^5.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -5997,6 +5997,15 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.2.tgz#cb3ae806e8740444584ef154ce8ee98d403f3e36"
   integrity sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
 
+query-string@5:
+  version "5.1.1"
+  resolved "https://registry.yarnpkg.com/query-string/-/query-string-5.1.1.tgz#a78c012b71c17e05f2e3fa2319dd330682efb3cb"
+  integrity sha512-gjWOsm2SoGlgLEdAGt7a6slVOk9mGiXmPFMqrEhLQ68rhQuBnpfs3+EmlvqKyxnCo9/PPlF+9MtY02S1aFg+Jw==
+  dependencies:
+    decode-uri-component "^0.2.0"
+    object-assign "^4.1.0"
+    strict-uri-encode "^1.0.0"
+
 querystring-es3@^0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/querystring-es3/-/querystring-es3-0.2.1.tgz#9ec61f79049875707d69414596fd907a4d711e73"
@@ -6906,6 +6915,11 @@ stream-shift@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/stream-shift/-/stream-shift-1.0.0.tgz#d5c752825e5367e786f78e18e445ea223a155952"
   integrity sha1-1cdSgl5TZ+eG944Y5EXqIjoVWVI=
+
+strict-uri-encode@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/strict-uri-encode/-/strict-uri-encode-1.1.0.tgz#279b225df1d582b1f54e65addd4352e18faa0713"
+  integrity sha1-J5siXfHVgrH1TmWt3UNS4Y+qBxM=
 
 string-length@^2.0.0:
   version "2.0.0"


### PR DESCRIPTION
To make use of the filtering added in #141, the front end will need to send filters as query parameters. This adds an argument for query parameters to `api.get`.

Relates to #8