### PR TITLE
Raise validation errors from is_valid

### DIFF
--- a/curation_portal/views/project_admin.py
+++ b/curation_portal/views/project_admin.py
@@ -1,4 +1,3 @@
-from rest_framework.exceptions import ValidationError
 from rest_framework.permissions import DjangoModelPermissions, IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.serializers import ModelSerializer
@@ -20,8 +19,7 @@ class CreateProjectView(APIView):
 
     def post(self, request, *args, **kwargs):
         serializer = ProjectSerializer(data=request.data)
-        if not serializer.is_valid():
-            raise ValidationError(serializer.errors)
+        serializer.is_valid(raise_exception=True)
 
         project = serializer.save(created_by=request.user)
         project.owners.set([request.user])

--- a/curation_portal/views/project_assignments.py
+++ b/curation_portal/views/project_assignments.py
@@ -3,7 +3,7 @@ from collections import Counter, defaultdict
 from django.db import transaction
 from django.db.models import Prefetch
 from rest_framework import serializers
-from rest_framework.exceptions import NotFound, PermissionDenied, ValidationError
+from rest_framework.exceptions import NotFound, PermissionDenied
 from rest_framework.generics import get_object_or_404
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -58,7 +58,7 @@ class NewAssignmentListSerializer(serializers.ListSerializer):  # pylint: disabl
             for curator, variant_id in duplicate_assignments:
                 duplicates_by_curator[curator].append(variant_id)
 
-            raise ValidationError(
+            raise serializers.ValidationError(
                 "Duplicate assignments for "
                 + ", ".join(
                     f"{curator} (variants {', '.join(variants)})"
@@ -142,8 +142,7 @@ class ProjectAssignmentsView(APIView):
         serializer = NewAssignmentSerializer(
             data=request.data["assignments"], context={"project": project}, many=True
         )
-        if not serializer.is_valid():
-            raise ValidationError(serializer.errors)
+        serializer.is_valid(raise_exception=True)
 
         with transaction.atomic():
             serializer.save()

--- a/curation_portal/views/results.py
+++ b/curation_portal/views/results.py
@@ -1,5 +1,5 @@
 from django.db import transaction
-from rest_framework.exceptions import NotFound, PermissionDenied, ValidationError
+from rest_framework.exceptions import NotFound, PermissionDenied
 from rest_framework.generics import get_object_or_404
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -28,8 +28,7 @@ class ProjectResultsView(APIView):
         serializer = ImportedResultSerializer(
             data=request.data, context={"project": project}, many=True
         )
-        if not serializer.is_valid():
-            raise ValidationError(serializer.errors)
+        serializer.is_valid(raise_exception=True)
 
         with transaction.atomic():
             serializer.save()

--- a/curation_portal/views/variants.py
+++ b/curation_portal/views/variants.py
@@ -1,5 +1,5 @@
 from django.db import transaction
-from rest_framework.exceptions import NotFound, PermissionDenied, ValidationError
+from rest_framework.exceptions import NotFound, PermissionDenied
 from rest_framework.generics import get_object_or_404
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
@@ -43,8 +43,7 @@ class ProjectVariantsView(APIView):
         serializer = UploadedVariantSerializer(
             data=request.data, context={"project": project}, many=True
         )
-        if not serializer.is_valid():
-            raise ValidationError(serializer.errors)
+        serializer.is_valid(raise_exception=True)
 
         with transaction.atomic():
             serializer.save()


### PR DESCRIPTION
Use the [`raise_exception` argument](https://www.django-rest-framework.org/api-guide/serializers/#raising-an-exception-on-invalid-data) for `is_valid` instead of checking the return value and explicitly raising an error. This is less code and ensures consistency in the format of error responses.