### PR TITLE
Correct prop type

### DIFF
--- a/assets/components/pages/projects/AssignedProjectsPage.js
+++ b/assets/components/pages/projects/AssignedProjectsPage.js
@@ -65,9 +65,9 @@ const AssignedProjectsPage = ({ user }) => {
 };
 
 AssignedProjectsPage.propTypes = {
-  user: {
+  user: PropTypes.shape({
     username: PropTypes.string.isRequired,
-  },
+  }),
 };
 
 AssignedProjectsPage.defaultProps = {


### PR DESCRIPTION
This is currently throwing:
```
Warning: Failed prop type: AssignedProjectsPage: prop type `user` is invalid; it must be a function, usually from the `prop-types` package, but received `object`.
```