### PR TITLE
Update docs to point to deployment instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,7 @@
 ![Frontend CI status badge](https://github.com/broadinstitute/variant-curation-portal/actions/workflows/frontend-ci.yml/badge.svg)
 
 ![Backend CI status badge](https://github.com/broadinstitute/variant-curation-portal/actions/workflows/backend-ci.yml/badge.svg)
+
+## Development
+
+See [CONTRIBUTING.md](./CONTRIBUTING.md).

--- a/docs/deployment.md
+++ b/docs/deployment.md
@@ -4,6 +4,10 @@ The variant curation portal is a [Django](https://www.djangoproject.com/) applic
 Django provides [documentation](https://docs.djangoproject.com/en/2.2/howto/deployment/)
 on several options for deploying with WSGI.
 
+## Updating the production deployment
+
+See instructions in the private `lof-curation-portal-env` [Github repo](https://github.com/broadinstitute/lof-curation-portal-env/blob/main/README.md#deploy-app-updates).
+
 ## Dependencies
 
 Dependencies are listed in [requirements.txt](../requirements.txt).


### PR DESCRIPTION
Minor updates to docs
- Update readme to reference CONTRIBUTING.md
- Update deployment.md to reference deployment instructions in the private lof-curation-portal-env github repo