### PR TITLE
Fix broken GRCh38 behavior

### DIFF
--- a/assets/components/pages/project/admin/ProjectAdminPage.js
+++ b/assets/components/pages/project/admin/ProjectAdminPage.js
@@ -8,6 +8,9 @@ import DocumentTitle from "../../../DocumentTitle";
 import Page from "../../Page";
 
 const ProjectAdminPage = ({ project, user }) => {
+  const urlParams = new URLSearchParams(window.location.search);
+  const referenceGenome = urlParams.get("reference_genome") || "GRCh37";
+
   const curators = Object.keys(project.assignments || {});
   return (
     <Page>
@@ -57,7 +60,7 @@ const ProjectAdminPage = ({ project, user }) => {
                         as="a"
                         disabled={completed === 0}
                         download
-                        href={`/api/project/${project.id}/results/export/?curator__username=${curator}`}
+                        href={`/api/project/${project.id}/results/export/?curator__username=${curator}&reference_genome=${referenceGenome}`}
                       >
                         Download results
                       </Button>
@@ -83,7 +86,11 @@ const ProjectAdminPage = ({ project, user }) => {
         <p>
           <Link to={`/project/${project.id}/results/import/`}>Import curation results</Link>
         </p>
-        <Button as="a" download href={`/api/project/${project.id}/results/export/`}>
+        <Button
+          as="a"
+          download
+          href={`/api/project/${project.id}/results/export/?reference_genome=${referenceGenome}`}
+        >
           Download all results
         </Button>
       </PermissionRequired>

--- a/assets/components/pages/projects/AssignedProjectsPage.js
+++ b/assets/components/pages/projects/AssignedProjectsPage.js
@@ -8,6 +8,9 @@ import Fetch from "../../Fetch";
 import Page from "../Page";
 
 const AssignedProjectsPage = ({ user }) => {
+  const urlParams = new URLSearchParams(window.location.search);
+  const referenceGenome = urlParams.get("reference_genome") || "GRCh37";
+
   return (
     <Page>
       <DocumentTitle title="Assignments" />
@@ -42,7 +45,7 @@ const AssignedProjectsPage = ({ user }) => {
                             as="a"
                             disabled={project.variants_curated === 0}
                             download
-                            href={`/api/project/${project.id}/results/export/?curator__username=${user.username}`}
+                            href={`/api/project/${project.id}/results/export/?curator__username=${user.username}&reference_genome=${referenceGenome}`}
                           >
                             Download results
                           </Button>

--- a/assets/components/pages/variant/VariantProjectsPage.js
+++ b/assets/components/pages/variant/VariantProjectsPage.js
@@ -10,9 +10,7 @@ import Page from "../Page";
 
 const VariantProjectsPage = ({ variantId }) => {
   const urlParams = new URLSearchParams(window.location.search);
-  const referenceGenome = urlParams.get("reference_genome");
-
-  const referenceGenomeParam = referenceGenome ? `?reference_genome=${referenceGenome}` : "";
+  const referenceGenome = urlParams.get("reference_genome") || "GRCh37";
 
   return (
     <Page>
@@ -22,11 +20,11 @@ const VariantProjectsPage = ({ variantId }) => {
       </Header>
 
       <p>
-        <Link to={`/variants/${referenceGenomeParam}`}>Return to all variants</Link>
+        <Link to={`/variants/?reference_genome=${referenceGenome}`}>Return to all variants</Link>
       </p>
 
       <p>
-        <Link to={`/variant/${variantId}/results/${referenceGenomeParam}`}>
+        <Link to={`/variant/${variantId}/results/?reference_genome=${referenceGenome}`}>
           View all results for this variant
         </Link>
       </p>

--- a/assets/components/pages/variant/VariantProjectsPage.js
+++ b/assets/components/pages/variant/VariantProjectsPage.js
@@ -12,6 +12,8 @@ const VariantProjectsPage = ({ variantId }) => {
   const urlParams = new URLSearchParams(window.location.search);
   const referenceGenome = urlParams.get("reference_genome");
 
+  const referenceGenomeParam = referenceGenome ? `?reference_genome=${referenceGenome}` : "";
+
   return (
     <Page>
       <DocumentTitle title={`Projects | ${variantId}`} />
@@ -20,11 +22,13 @@ const VariantProjectsPage = ({ variantId }) => {
       </Header>
 
       <p>
-        <Link to="/variants/">Return to all variants</Link>
+        <Link to={`/variants/${referenceGenomeParam}`}>Return to all variants</Link>
       </p>
 
       <p>
-        <Link to={`/variant/${variantId}/results/`}>View all results for this variant</Link>
+        <Link to={`/variant/${variantId}/results/${referenceGenomeParam}`}>
+          View all results for this variant
+        </Link>
       </p>
 
       <Fetch

--- a/assets/components/pages/variant/VariantResultsPage.js
+++ b/assets/components/pages/variant/VariantResultsPage.js
@@ -26,7 +26,12 @@ const VariantResultsPage = ({ variantId }) => {
       </p>
 
       <p>
-        <Button as="a" disabled={false} download href={`/api/variant/${variantId}/results/export/`}>
+        <Button
+          as="a"
+          disabled={false}
+          download
+          href={`/api/variant/${variantId}/results/export/?reference_genome=${referenceGenome}`}
+        >
           Download results
         </Button>
       </p>

--- a/assets/components/pages/variant/VariantResultsPage.js
+++ b/assets/components/pages/variant/VariantResultsPage.js
@@ -11,6 +11,9 @@ import VariantId from "../../VariantId";
 import Page from "../Page";
 
 const VariantResultsPage = ({ variantId }) => {
+  const urlParams = new URLSearchParams(window.location.search);
+  const referenceGenome = urlParams.get("reference_genome") || "GRCh37";
+
   return (
     <Page>
       <DocumentTitle title={`Results | ${variantId}`} />
@@ -28,7 +31,7 @@ const VariantResultsPage = ({ variantId }) => {
         </Button>
       </p>
 
-      <Fetch path={`/variant/${variantId}/results/`}>
+      <Fetch path={`/variant/${variantId}/results/`} params={{ reference_genome: referenceGenome }}>
         {({ data: { results } }) => {
           return (
             <Table>

--- a/curation_portal/views/variant_results.py
+++ b/curation_portal/views/variant_results.py
@@ -59,10 +59,17 @@ class VariantResultsView(APIView):
     permission_classes = (IsAuthenticated,)
 
     def get(self, request, *args, **kwargs):  # pylint: disable=unused-argument
+
+        reference_genome = (
+            request.query_params["reference_genome"]
+            if "reference_genome" in request.query_params
+            else "GRCh37"
+        )
+
         variants = (
             Variant.objects.filter(
                 Q(variant_id=kwargs["variant_id"])
-                & Q(reference_genome="GRCh37")  # TODO: Handle different reference genomes
+                & Q(reference_genome=reference_genome)
                 & (
                     Q(project__owners__id__contains=request.user.id)
                     | Q(curation_assignment__curator=request.user)
@@ -79,8 +86,8 @@ class VariantResultsView(APIView):
             CurationResult.objects.filter(
                 Q(assignment__variant__variant_id=kwargs["variant_id"])
                 & Q(
-                    assignment__variant__reference_genome="GRCh37"
-                )  # TODO: Handle different reference genomes
+                    assignment__variant__reference_genome=reference_genome
+                )
                 & (
                     Q(assignment__variant__project__owners__id__contains=request.user.id)
                     | Q(assignment__curator=request.user)


### PR DESCRIPTION
Resolves #280,
Resolves #282,

When gnomAD v4 (and with it the first GRCh38 variants in VCP) some, but not all of the views were and frontend pages were changed to allow usage of a query param to determine which subset of the variant objects in django to get.

This PR addresses all remaining cases that were mistakenly not implemented. In particular this lets users see all results for a particular GRCh38 variant, and to download a `.csv` summarizing the results for a given GRCh38 variant.