### PR TITLE
Turn UCSC browser view into links

### DIFF
--- a/.github/workflows/backend-ci.yml
+++ b/.github/workflows/backend-ci.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           python-version: 3.9
       - name: Use pip cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ~/.cache/pip
           key: pip-${{ hashFiles('**/requirements*.txt') }}

--- a/.github/workflows/frontend-ci.yml
+++ b/.github/workflows/frontend-ci.yml
@@ -27,7 +27,7 @@ jobs:
         id: yarn-cache
         run: echo "::set-output name=dir::$(yarn cache dir)"
       - name: Use yarn cache
-        uses: actions/cache@v1
+        uses: actions/cache@v4
         with:
           path: ${{ steps.yarn-cache.outputs.dir }}
           key: yarn-${{ hashFiles('**/yarn.lock') }}

--- a/assets/components/pages/project/curate/UCSC.js
+++ b/assets/components/pages/project/curate/UCSC.js
@@ -21,22 +21,13 @@ export const UCSCVariantView = ({ settings, variant }) => {
     url = `${url}&hgS_doOtherUser=submit&hgS_otherUserName=${settings.ucsc_username}&hgS_otherUserSessionName=${settings.ucsc_session_name}`;
   }
 
-  if (process.env.NODE_ENV === "development") {
-    return (
-      <Segment placeholder id="ucsc" textAlign="center">
-        <p>UCSC variant view</p>
-        <a href={url}>{url}</a>
-      </Segment>
-    );
-  }
-
   return (
-    <iframe
-      title="UCSC variant view"
-      id="ucsc"
-      src={url}
-      style={{ width: "100%", height: "4000px" }}
-    />
+    <Segment placeholder id="ucsc" textAlign="center">
+      <p>UCSC variant view</p>
+      <a href={url} target="_blank" rel="noopener noreferrer">
+        {url}
+      </a>
+    </Segment>
   );
 };
 
@@ -82,22 +73,13 @@ export const UCSCGeneView = ({ settings, variant }) => {
     url = `${url}&hgS_doOtherUser=submit&hgS_otherUserName=${settings.ucsc_username}&hgS_otherUserSessionName=${settings.ucsc_session_name}`;
   }
 
-  if (process.env.NODE_ENV === "development") {
-    return (
-      <Segment placeholder id="ucsc-gene" textAlign="center">
-        <p>UCSC gene view</p>
-        <a href={url}>{url}</a>
-      </Segment>
-    );
-  }
-
   return (
-    <iframe
-      title="UCSC gene view"
-      id="ucsc-gene"
-      src={url}
-      style={{ width: "100%", height: "4000px" }}
-    />
+    <Segment placeholder id="ucsc-gene" textAlign="center">
+      <p>UCSC gene view</p>
+      <a href={url} target="_blank" rel="noopener noreferrer">
+        {url}
+      </a>
+    </Segment>
   );
 };
 


### PR DESCRIPTION
Resolves: #294

Previously we used an `<iframe>` to just render the UCSC browser within our own page. Now, the UCSC browser uses a captcha to prevent (presumably) an increase in traffic from bots. There is no simple way to continue our usage of an iframe, as we can't set cookies from a different webpage embedded in our single page.

For now, just link out to UCSC so that curators can easily get to the same views.